### PR TITLE
fix packaging with setup.py (was looking for README.txt not README.rst)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
 		'enum', 'encode', 'decode', 'serialize', 'deserialize'],
 	version='3.11.1',
 	packages=['json_tricks', 'tests'],
-	data_files = [("", ["LICENSE.txt"]), ("", ["README.txt"]), ("", ["tox.ini"])],
+	data_files = [("", ["LICENSE.txt"]), ("", ["README.rst"]), ("", ["tox.ini"])],
 	include_package_data=True,
 	zip_safe=False,
 	classifiers=[


### PR DESCRIPTION
Packaging was failing as a result of this. e.g:

```bash
Building wheels for collected packages: json-tricks, pyparallel
  Running setup.py bdist_wheel for json-tricks ... error
  Complete output from command /home/travis/miniconda/envs/psychopy-conda/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-6rLvsO/json-tricks/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpVx6DlCpip-wheel- --python-tag cp27:
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib
  creating build/lib/json_tricks
  copying json_tricks/comment.py -> build/lib/json_tricks
  copying json_tricks/utils.py -> build/lib/json_tricks
  copying json_tricks/np.py -> build/lib/json_tricks
  copying json_tricks/np_utils.py -> build/lib/json_tricks
  copying json_tricks/decoders.py -> build/lib/json_tricks
  copying json_tricks/nonp.py -> build/lib/json_tricks
  copying json_tricks/encoders.py -> build/lib/json_tricks
  copying json_tricks/__init__.py -> build/lib/json_tricks
  creating build/lib/tests
  copying tests/test_tz.py -> build/lib/tests
  copying tests/test_class.py -> build/lib/tests
  copying tests/test_bare.py -> build/lib/tests
  copying tests/test_utils.py -> build/lib/tests
  copying tests/test_pandas.py -> build/lib/tests
  copying tests/test_enum.py -> build/lib/tests
  copying tests/__init__.py -> build/lib/tests
  copying tests/test_np.py -> build/lib/tests
  running egg_info
  writing json_tricks.egg-info/PKG-INFO
  writing top-level names to json_tricks.egg-info/top_level.txt
  writing dependency_links to json_tricks.egg-info/dependency_links.txt
  reading manifest file 'json_tricks.egg-info/SOURCES.txt'
  writing manifest file 'json_tricks.egg-info/SOURCES.txt'
  installing to build/bdist.linux-x86_64/wheel
  running install
  running install_lib
  creating build/bdist.linux-x86_64
  creating build/bdist.linux-x86_64/wheel
  creating build/bdist.linux-x86_64/wheel/tests
  copying build/lib/tests/test_tz.py -> build/bdist.linux-x86_64/wheel/tests
  copying build/lib/tests/test_class.py -> build/bdist.linux-x86_64/wheel/tests
  copying build/lib/tests/test_bare.py -> build/bdist.linux-x86_64/wheel/tests
  copying build/lib/tests/test_utils.py -> build/bdist.linux-x86_64/wheel/tests
  copying build/lib/tests/test_pandas.py -> build/bdist.linux-x86_64/wheel/tests
  copying build/lib/tests/test_enum.py -> build/bdist.linux-x86_64/wheel/tests
  copying build/lib/tests/__init__.py -> build/bdist.linux-x86_64/wheel/tests
  copying build/lib/tests/test_np.py -> build/bdist.linux-x86_64/wheel/tests
  creating build/bdist.linux-x86_64/wheel/json_tricks
  copying build/lib/json_tricks/comment.py -> build/bdist.linux-x86_64/wheel/json_tricks
  copying build/lib/json_tricks/utils.py -> build/bdist.linux-x86_64/wheel/json_tricks
  copying build/lib/json_tricks/np.py -> build/bdist.linux-x86_64/wheel/json_tricks
  copying build/lib/json_tricks/np_utils.py -> build/bdist.linux-x86_64/wheel/json_tricks
  copying build/lib/json_tricks/decoders.py -> build/bdist.linux-x86_64/wheel/json_tricks
  copying build/lib/json_tricks/nonp.py -> build/bdist.linux-x86_64/wheel/json_tricks
  copying build/lib/json_tricks/encoders.py -> build/bdist.linux-x86_64/wheel/json_tricks
  copying build/lib/json_tricks/__init__.py -> build/bdist.linux-x86_64/wheel/json_tricks
  running install_data
  creating build/bdist.linux-x86_64/wheel/json_tricks-3.11.1.data
  creating build/bdist.linux-x86_64/wheel/json_tricks-3.11.1.data/data
  copying LICENSE.txt -> build/bdist.linux-x86_64/wheel/json_tricks-3.11.1.data/data/
  error: can't copy 'README.txt': doesn't exist or not a regular file
  ```