### PR TITLE
Localize datetimes after creating naive versions, to work around pytz issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 /.tox/
 .coverage
 coverage.xml
+.pytest_cache/
+

--- a/json_tricks/decoders.py
+++ b/json_tricks/decoders.py
@@ -72,9 +72,12 @@ def json_date_time_hook(dct):
 			microsecond=dct.get('microsecond', 0), tzinfo=tzinfo)
 	elif '__datetime__' in dct:
 		tzinfo = get_tz(dct)
-		return datetime(year=dct.get('year', 0), month=dct.get('month', 0), day=dct.get('day', 0),
+		dt = datetime(year=dct.get('year', 0), month=dct.get('month', 0), day=dct.get('day', 0),
 			hour=dct.get('hour', 0), minute=dct.get('minute', 0), second=dct.get('second', 0),
-			microsecond=dct.get('microsecond', 0), tzinfo=tzinfo)
+			microsecond=dct.get('microsecond', 0))
+		if tzinfo is None:
+			return dt
+		return tzinfo.localize(dt)
 	elif '__timedelta__' in dct:
 		return timedelta(days=dct.get('days', 0), seconds=dct.get('seconds', 0),
 			microseconds=dct.get('microseconds', 0))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sys import version_info
-from logging import warn
+from logging import warning
 
 from setuptools import setup
 
@@ -17,7 +17,7 @@ if version_info < (2, 7, 0):
 if (version_info[0] == 2 and version_info[1] < 7) or \
 		(version_info[0] == 3 and version_info[1] < 4) or \
 		version_info[0] not in (2, 3):
-	raise warn('`json_tricks` does not support Python version {}.{}'
+	raise warning('`json_tricks` does not support Python version {}.{}'
 		.format(version_info[0], version_info[1]))
 
 setup(
@@ -32,7 +32,7 @@ setup(
 	license='Revised BSD License (LICENSE.txt)',
 	keywords=['json', 'numpy', 'OrderedDict', 'comments', 'pandas', 'pytz',
 		'enum', 'encode', 'decode', 'serialize', 'deserialize'],
-	version='3.11.2',
+	version='3.11.3',
 	packages=['json_tricks'],
 	include_package_data=True,
 	zip_safe=True,

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -64,10 +64,4 @@ def test_avoiding_tz_datettime_problem():
 		"Mismatch due to pytz localizing error {} != {}".format(
 			pytz.utc.normalize(tzdt), pytz.utc.normalize(back))
 
-	## Not sure if this affects timezones; localize and normalize don't apply
-	# tdt = time(12, 0, 0, 0, tzinfo=pytz.timezone('US/Pacific'))
-	# back = loads(dumps([tdt]))[0]
-	# assert tdt == back, \
-	# 	"Mismatch due to pytz localizing error {} != {}".format(tdt, back)
-
 


### PR DESCRIPTION
Times are not included, only datetimes. Resolves issue #41.