### PR TITLE
Optimize kwargs filter for less calls to signature()

### DIFF
--- a/json_tricks/utils.py
+++ b/json_tricks/utils.py
@@ -42,15 +42,6 @@ else:
 		return set(sig.parameters.keys())
 
 
-def call_with_optional_kwargs(callable, *args, **optional_kwargs):
-	accepted_kwargs = get_arg_names(callable)
-	use_kwargs = {}
-	for key, val in optional_kwargs.items():
-		if key in accepted_kwargs:
-			use_kwargs[key] = val
-	return callable(*args, **use_kwargs)
-
-
 class NoNumpyException(Exception):
 	""" Trying to use numpy features, but numpy cannot be found. """
 


### PR DESCRIPTION
Before this, if you had large datasets with a lot of objects, a huge
part of the runtime went into inspect.signature() which was called for
every object times every encoder.

As the signatures of the encoders does not change, we can simplify this
and get the signatures only once. This reduced the runtime on a 1mb test
dataset from about 15s to 2s for encoding.

