### PR TITLE
Disambiguate datetimes that happen during a DST fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ As well as compression and disallowing duplicate keys.
 Several keys of the format `__keyname__` have special meanings, and more
 might be added in future releases.
 
-If you\'re considering JSON-but-with-comments as a config file format,
+If you're considering JSON-but-with-comments as a config file format,
 have a look at [HJSON](https://github.com/hjson/hjson-py), it might be
 more appropriate. For other purposes, keep reading!
 
@@ -78,19 +78,20 @@ which will be converted back to a numpy array when using
 `json_tricks.loads`. Note that the memory order (`Corder`) is only
 stored in v3.1 and later and for arrays with at least 2 dimensions.
 
-As you see, this uses the magic key `__ndarray__`. Don\'t use
-`__ndarray__` as a dictionary key unless you\'re trying to make a numpy
-array (and know what you\'re doing).
+As you see, this uses the magic key `__ndarray__`. Don't use
+`__ndarray__` as a dictionary key unless you're trying to make a numpy
+array (and know what you're doing).
 
 Numpy scalars are also serialized (v3.5+). They are represented by the
 closest python primitive type. A special representation was not
-feasible, because Python\'s json implementation serializes some numpy
+feasible, because Python's json implementation serializes some numpy
 types as primitives, without consulting custom encoders. If you want to
 preserve the exact numpy type, use
 [encode_scalars_inplace](https://json-tricks.readthedocs.io/en/latest/#json_tricks.np_utils.encode_scalars_inplace).
 
-There is also a compressed format. From the next major release, this
-will be default when using compression. For now you can use it as:
+There is also a compressed format (thanks `claydugo` for fix). From 
+the next major release, this will be default when using compression.
+For now, you can use it as:
 
 ``` python
 dumps(data, compression=True, properties={'ndarray_compact': True})
@@ -124,7 +125,7 @@ dumps(data, compression=False, properties={'ndarray_compact': 8})
 `json_tricks` can serialize class instances.
 
 If the class behaves normally (not generated dynamic, no `__new__` or
-`__metaclass__` magic, etc) *and* all it\'s attributes are serializable,
+`__metaclass__` magic, etc) *and* all it's attributes are serializable,
 then this should work by default.
 
 ``` python
@@ -140,7 +141,7 @@ json = dumps(cls_instance, indent=4)
 cls_instance_again = loads(json)
 ```
 
-You\'ll get your instance back. Here the json looks like this:
+You'll get your instance back. Here the json looks like this:
 
 ``` javascript
 {
@@ -159,12 +160,12 @@ You\'ll get your instance back. Here the json looks like this:
 
 As you can see, this stores the module and class name. The class must be
 importable from the same module when decoding (and should not have
-changed). If it isn\'t, you have to manually provide a dictionary to
+changed). If it isn't, you have to manually provide a dictionary to
 `cls_lookup_map` when loading in which the class name can be looked up.
 Note that if the class is imported, then `globals()` is such a
 dictionary (so try `loads(json, cls_lookup_map=glboals())`). Also note
-that if the class is defined in the \'top\' script (that you\'re calling
-directly), then this isn\'t a module and the import part cannot be
+that if the class is defined in the 'top' script (that you're calling
+directly), then this isn't a module and the import part cannot be
 extracted. Only the class name will be stored; it can then only be
 deserialized in the same script, or if you provide `cls_lookup_map`.
 
@@ -180,7 +181,7 @@ indentation):
 }
 ```
 
-If the instance doesn\'t serialize automatically, or if you want custom
+If the instance doesn't serialize automatically, or if you want custom
 behaviour, then you can implement `__json__encode__(self)` and
 `__json_decode__(self, **attributes)` methods, like so:
 
@@ -200,18 +201,18 @@ def __init__(self):
     self.irrelevant = 12
 ```
 
-As you\'ve seen, this uses the magic key `__instance_type__`. Don\'t use
-`__instance_type__` as a dictionary key unless you know what you\'re
+As you've seen, this uses the magic key `__instance_type__`. Don't use
+`__instance_type__` as a dictionary key unless you know what you're
 doing.
 
 ## Date, time, datetime and timedelta
 
 Date, time, datetime and timedelta objects are stored as dictionaries of
-\"day\", \"hour\", \"millisecond\" etc keys, for each nonzero property.
+"day", "hour", "millisecond" etc keys, for each nonzero property.
 
-Timezone name is also stored in case it is set. You\'ll need to have
-`pytz` installed to use timezone-aware date/times, it\'s not needed for
-naive date/times.
+Timezone name is also stored in case it is set, as is DST (thanks `eumir`).
+You'll need to have `pytz` installed to use timezone-aware date/times, 
+it's not needed for naive date/times.
 
 ``` javascript
 {
@@ -230,11 +231,11 @@ naive date/times.
 This approach was chosen over timestamps for readability and consistency
 between date and time, and over a single string to prevent parsing
 problems and reduce dependencies. Note that if `primitives=True`,
-date/times are encoded as ISO 8601, but they won\'t be restored
+date/times are encoded as ISO 8601, but they won't be restored
 automatically.
 
-Don\'t use `__date__`, `__time__`, `__datetime__`, `__timedelta__` or
-`__tzinfo__` as dictionary keys unless you know what you\'re doing, as
+Don't use `__date__`, `__time__`, `__datetime__`, `__timedelta__` or
+`__tzinfo__` as dictionary keys unless you know what you're doing, as
 they have special meaning.
 
 ## Order
@@ -258,7 +259,7 @@ ordered = loads(json, preserve_order=True)
 ```
 
 where `preserve_order=True` is added for emphasis; it can be left out
-since it\'s the default.
+since it's the default.
 
 As a note on [performance](http://stackoverflow.com/a/8177061/723090),
 both dicts and OrderedDicts have the same scaling for getting and
@@ -282,9 +283,9 @@ common conventions, though only the latter is valid javascript.
 For example, you could call `loads` on the following string:
 
 { # "comment 1
-    "hello": "Wor#d", "Bye": "\"M#rk\"", "yes\\\"": 5,# comment" 2
-    "quote": "\"th#t's\" what she said", // comment "3"
-    "list": [1, 1, "#", "\"", "\\", 8], "dict": {"q": 7} #" comment 4 with quotes
+    "hello": "Wor#d", "Bye": ""M#rk"", "yes\\"": 5,# comment" 2
+    "quote": ""th#t's" what she said", // comment "3"
+    "list": [1, 1, "#", """, "\", 8], "dict": {"q": 7} #" comment 4 with quotes
 }
 // comment 5
 
@@ -292,9 +293,9 @@ And it would return the de-commented version:
 
 ``` javascript
 {
-    "hello": "Wor#d", "Bye": "\"M#rk\"", "yes\\\"": 5,
-    "quote": "\"th#t's\" what she said",
-    "list": [1, 1, "#", "\"", "\\", 8], "dict": {"q": 7}
+    "hello": "Wor#d", "Bye": ""M#rk"", "yes\\"": 5,
+    "quote": ""th#t's" what she said",
+    "list": [1, 1, "#", """, "\", 8], "dict": {"q": 7}
 }
 ```
 
@@ -353,9 +354,9 @@ documentation refer to that format.
 
 You can also choose to store things as their closest primitive type
 (e.g. arrays and sets as lists, decimals as floats). This may be
-desirable if you don\'t care about the exact type, or you are loading
-the json in another language (which doesn\'t restore python types).
-It\'s also smaller.
+desirable if you don't care about the exact type, or you are loading
+the json in another language (which doesn't restore python types).
+It's also smaller.
 
 To forego meta data and store primitives instead, pass `primitives` to
 `dump(s)`. This is available in version `3.8` and later. Example:
@@ -457,7 +458,7 @@ print(dumps(data, primitives=True))
 Note that valid json is produced either way: ``json-tricks`` stores meta data as normal json, but other packages probably won't interpret it.
 
 Note that valid json is produced either way: `json-tricks` stores meta
-data as normal json, but other packages probably won\'t interpret it.
+data as normal json, but other packages probably won't interpret it.
 
 # Usage & contributions
 

--- a/json_tricks/decoders.py
+++ b/json_tricks/decoders.py
@@ -40,7 +40,7 @@ class TricksPairHook(object):
 				if key in known:
 					raise DuplicateJsonKeyException(('Trying to load a json map which contains a ' +
 						'duplicate key "{0:}" (but allow_duplicates is False)').format(key))
-				known.add(key)
+			known.add(key)
 		map = self.map_type(pairs)
 		for hook in self.obj_pairs_hooks:
 			map = hook(map, properties=self.properties)
@@ -80,7 +80,7 @@ def json_date_time_hook(dct):
 			microsecond=dct.get('microsecond', 0))
 		if tzinfo is None:
 			return dt
-		return tzinfo.localize(dt)
+		return tzinfo.localize(dt, is_dst=dct.get('is_dst', None))
 	elif '__timedelta__' in dct:
 		return timedelta(days=dct.get('days', 0), seconds=dct.get('seconds', 0),
 			microseconds=dct.get('microseconds', 0))

--- a/json_tricks/decoders.py
+++ b/json_tricks/decoders.py
@@ -40,7 +40,7 @@ class TricksPairHook(object):
 				if key in known:
 					raise DuplicateJsonKeyException(('Trying to load a json map which contains a ' +
 						'duplicate key "{0:}" (but allow_duplicates is False)').format(key))
-			known.add(key)
+				known.add(key)
 		map = self.map_type(pairs)
 		for hook in self.obj_pairs_hooks:
 			map = hook(map, properties=self.properties)

--- a/json_tricks/encoders.py
+++ b/json_tricks/encoders.py
@@ -100,6 +100,7 @@ def json_date_time_encode(obj, primitives=False):
 				dct['tzinfo'] = obj.tzinfo.zone
 			else:
 				dct['tzinfo'] = obj.tzinfo.tzname(None)
+            dct['is_dst'] = bool(obj.dst())
 	elif isinstance(obj, date):
 		dct = hashodict([('__date__', None), ('year', obj.year), ('month', obj.month), ('day', obj.day)])
 	elif isinstance(obj, time):
@@ -119,7 +120,7 @@ def json_date_time_encode(obj, primitives=False):
 	else:
 		return obj
 	for key, val in tuple(dct.items()):
-		if not key.startswith('__') and not val:
+		if not key.startswith('__') and not key == 'is_dst' and not val:
 			del dct[key]
 	return dct
 

--- a/json_tricks/encoders.py
+++ b/json_tricks/encoders.py
@@ -100,7 +100,7 @@ def json_date_time_encode(obj, primitives=False):
 				dct['tzinfo'] = obj.tzinfo.zone
 			else:
 				dct['tzinfo'] = obj.tzinfo.tzname(None)
-            dct['is_dst'] = bool(obj.dst())
+			dct['is_dst'] = bool(obj.dst())
 	elif isinstance(obj, date):
 		dct = hashodict([('__date__', None), ('year', obj.year), ('month', obj.month), ('day', obj.day)])
 	elif isinstance(obj, time):

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -27,7 +27,7 @@ DTOBJ = [
 ]
 
 
-def test_tzaware_date_time():
+def test_tzaware_date_time_without_dst():
 	json = dumps(DTOBJ)
 	back = loads(json)
 	assert DTOBJ == back
@@ -67,3 +67,20 @@ def test_avoiding_tz_datettime_problem():
 			pytz.utc.normalize(tzdt), pytz.utc.normalize(back))
 
 
+def test_before_dst_fold():
+	# issue #89
+	before_dst = datetime(2023, 10, 29, 0, 30, 0, 0, pytz.UTC)\
+		.astimezone(pytz.timezone("Europe/Paris"))
+	back = loads(dumps(before_dst))
+	assert back == before_dst
+	assert back.tzinfo.zone == before_dst.tzinfo.zone
+	assert back.utcoffset() == before_dst.utcoffset()
+
+
+def test_after_dst_fold():
+	after_dst = datetime(2023, 10, 29, 1, 30, 0, 0, pytz.UTC)\
+		.astimezone(pytz.timezone("Europe/Paris"))
+	back = loads(dumps(after_dst))
+	assert back == after_dst
+	assert back.tzinfo.zone == after_dst.tzinfo.zone
+	assert back.utcoffset() == after_dst.utcoffset()

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -13,74 +13,94 @@ import pytz
 
 
 DTOBJ = [
-	datetime(year=1988, month=3, day=15, hour=8, minute=3, second=59, microsecond=7),
+    datetime(year=1988, month=3, day=15, hour=8, minute=3, second=59, microsecond=7),
 	datetime.now(timezone.utc),
-	pytz.UTC.localize(datetime(year=1988, month=3, day=15, minute=3, second=59, microsecond=7)),
-	pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, microsecond=7)),
-	date(year=1988, month=3, day=15),
-	time(hour=8, minute=3, second=59, microsecond=123),
-	time(hour=8, second=59, microsecond=123, tzinfo=pytz.timezone('Europe/Amsterdam')),
+    pytz.UTC.localize(datetime(year=1988, month=3, day=15, minute=3, second=59, microsecond=7)),
+    pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, microsecond=7)),
+    date(year=1988, month=3, day=15),
+    time(hour=8, minute=3, second=59, microsecond=123),
+    time(hour=8, second=59, microsecond=123, tzinfo=pytz.timezone('Europe/Amsterdam')),
 	time(hour=8, second=59, microsecond=123, tzinfo=timezone.utc),
-	timedelta(days=2, seconds=3599),
-	timedelta(days=0, seconds=-42, microseconds=123),
-	[{'obj': [pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, microsecond=7))]}],
+    timedelta(days=2, seconds=3599),
+    timedelta(days=0, seconds=-42, microseconds=123),
+    [{'obj': [pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, microsecond=7))]}],
 ]
 
 
 def test_tzaware_date_time_without_dst():
-	json = dumps(DTOBJ)
-	back = loads(json)
-	assert DTOBJ == back
-	for orig, bck in zip(DTOBJ, back):
-		assert orig == bck
-		assert type(orig) == type(bck)
-	txt = '{"__datetime__": null, "year": 1988, "month": 3, "day": 15, "hour": 8, "minute": 3, ' \
-			'"second": 59, "microsecond": 7, "tzinfo": "Europe/Amsterdam"}'
-	obj = loads(txt)
-	assert obj == pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, hour=8, minute=3, second=59, microsecond=7))
+    json = dumps(DTOBJ)
+    back = loads(json)
+    assert DTOBJ == back
+    for orig, bck in zip(DTOBJ, back):
+        assert orig == bck
+        assert type(orig) == type(bck)
+    txt = '{"__datetime__": null, "year": 1988, "month": 3, "day": 15, "hour": 8, "minute": 3, ' \
+          '"second": 59, "microsecond": 7, "tzinfo": "Europe/Amsterdam"}'
+    obj = loads(txt)
+    assert obj == pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, hour=8, minute=3, second=59, microsecond=7))
+
+
+def test_tzaware_date_time_with_dst():
+    json = dumps(DTOBJ)
+    back = loads(json)
+    assert DTOBJ == back
+    for orig, bck in zip(DTOBJ, back):
+        assert orig == bck
+        assert type(orig) == type(bck)
+    txt = '{"__datetime__": null, "year": 1988, "month": 3, "day": 15, "hour": 8, "minute": 3, ' \
+          '"second": 59, "microsecond": 7, "tzinfo": "Europe/Amsterdam", "is_dst": true}'
+    obj = loads(txt)
+    assert obj == pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, hour=8, minute=3, second=59, microsecond=7))
 
 
 def test_tzaware_naive_date_time():
-	json = dumps(DTOBJ, primitives=True)
-	back = loads(json)
-	for orig, bck in zip(DTOBJ, back):
-		if isinstance(bck, (date, time, datetime,)):
-			assert isinstance(bck, str if is_py3 else (str, unicode))
-			assert bck == orig.isoformat()
-		elif isinstance(bck, (timedelta,)):
-			assert isinstance(bck, float)
-			assert bck == orig.total_seconds()
-	dt = pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, hour=8, minute=3, second=59, microsecond=7))
-	assert dumps(dt, primitives=True).strip('"') == '1988-03-15T08:03:59.000007+01:00'
+    json = dumps(DTOBJ, primitives=True)
+    back = loads(json)
+    for orig, bck in zip(DTOBJ, back):
+        if isinstance(bck, (date, time, datetime,)):
+            assert isinstance(bck, str if is_py3 else (str, unicode))
+            assert bck == orig.isoformat()
+        elif isinstance(bck, (timedelta,)):
+            assert isinstance(bck, float)
+            assert bck == orig.total_seconds()
+    dt = pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, hour=8, minute=3, second=59, microsecond=7))
+    assert dumps(dt, primitives=True).strip('"') == '1988-03-15T08:03:59.000007+01:00'
 
 
 def test_avoiding_tz_datettime_problem():
-	"""
-	There's a weird problem (bug? feature?) when passing timezone object to datetime constructor. This tests checks that json_tricks doesn't suffer from this problem.
-	https://github.com/mverleg/pyjson_tricks/issues/41  /  https://stackoverflow.com/a/25390097/723090
-	"""
-	tzdt = datetime(2007, 12, 5, 6, 30, 0, 1)
-	tzdt = pytz.timezone('US/Pacific').localize(tzdt)
-	back = loads(dumps([tzdt]))[0]
-	assert pytz.utc.normalize(tzdt) == pytz.utc.normalize(back), \
-		"Mismatch due to pytz localizing error {} != {}".format(
-			pytz.utc.normalize(tzdt), pytz.utc.normalize(back))
+    """
+    There's a weird problem (bug? feature?) when passing timezone object to datetime constructor. This tests checks that json_tricks doesn't suffer from this problem.
+    https://github.com/mverleg/pyjson_tricks/issues/41  /  https://stackoverflow.com/a/25390097/723090
+    """
+    tzdt = datetime(2007, 12, 5, 6, 30, 0, 1)
+    tzdt = pytz.timezone('US/Pacific').localize(tzdt)
+    back = loads(dumps([tzdt]))[0]
+    assert pytz.utc.normalize(tzdt) == pytz.utc.normalize(back), \
+        "Mismatch due to pytz localizing error {} != {}".format(
+            pytz.utc.normalize(tzdt), pytz.utc.normalize(back))
+
+
+def test_serialization_remains_unchanged():
+    json = dumps(datetime(2023, 10, 29, 1, 30, 0, 0, pytz.UTC) \
+                 .astimezone(pytz.timezone("Europe/Paris")))
+    assert json == '{"__datetime__": null, "year": 2023, "month": 10, "day": 29, ' \
+                   '"hour": 2, "minute": 30, "tzinfo": "Europe/Paris", "is_dst": false}'
 
 
 def test_before_dst_fold():
-	# issue #89
-	before_dst = datetime(2023, 10, 29, 0, 30, 0, 0, pytz.UTC)\
-		.astimezone(pytz.timezone("Europe/Paris"))
-	back = loads(dumps(before_dst))
-	assert back == before_dst
-	assert back.tzinfo.zone == before_dst.tzinfo.zone
-	assert back.utcoffset() == before_dst.utcoffset()
+    # issue #89
+    before_dst = datetime(2023, 10, 29, 0, 30, 0, 0, pytz.UTC) \
+        .astimezone(pytz.timezone("Europe/Paris"))
+    back = loads(dumps(before_dst))
+    assert back == before_dst
+    assert back.tzinfo.zone == before_dst.tzinfo.zone
+    assert back.utcoffset() == before_dst.utcoffset()
 
 
 def test_after_dst_fold():
-	after_dst = datetime(2023, 10, 29, 1, 30, 0, 0, pytz.UTC)\
-		.astimezone(pytz.timezone("Europe/Paris"))
-	back = loads(dumps(after_dst))
-	assert back == after_dst
-	assert back.tzinfo.zone == after_dst.tzinfo.zone
-	assert back.utcoffset() == after_dst.utcoffset()
+    after_dst = datetime(2023, 10, 29, 1, 30, 0, 0, pytz.UTC) \
+        .astimezone(pytz.timezone("Europe/Paris"))
+    back = loads(dumps(after_dst))
+    assert back == after_dst
+    assert back.tzinfo.zone == after_dst.tzinfo.zone
+    assert back.utcoffset() == after_dst.utcoffset()


### PR DESCRIPTION
As reported in #89. I can't get `.fold` to return anything but 0, so I am relying on `.dst()` instead.