### PR TITLE
Allow timezone.utc as the timezone in datetime and time objects

### DIFF
--- a/json_tricks/encoders.py
+++ b/json_tricks/encoders.py
@@ -96,14 +96,14 @@ def json_date_time_encode(obj, primitives=False):
 			('day', obj.day), ('hour', obj.hour), ('minute', obj.minute),
 			('second', obj.second), ('microsecond', obj.microsecond)])
 		if obj.tzinfo:
-			dct['tzinfo'] = obj.tzinfo.zone
+			dct['tzinfo'] = obj.tzinfo.tzname(None)
 	elif isinstance(obj, date):
 		dct = hashodict([('__date__', None), ('year', obj.year), ('month', obj.month), ('day', obj.day)])
 	elif isinstance(obj, time):
 		dct = hashodict([('__time__', None), ('hour', obj.hour), ('minute', obj.minute),
 			('second', obj.second), ('microsecond', obj.microsecond)])
 		if obj.tzinfo:
-			dct['tzinfo'] = obj.tzinfo.zone
+			dct['tzinfo'] = obj.tzinfo.tzname(None)
 	elif isinstance(obj, timedelta):
 		if primitives:
 			return obj.total_seconds()

--- a/json_tricks/encoders.py
+++ b/json_tricks/encoders.py
@@ -96,14 +96,20 @@ def json_date_time_encode(obj, primitives=False):
 			('day', obj.day), ('hour', obj.hour), ('minute', obj.minute),
 			('second', obj.second), ('microsecond', obj.microsecond)])
 		if obj.tzinfo:
-			dct['tzinfo'] = obj.tzinfo.tzname(None)
+			if hasattr(obj.tzinfo, 'zone'):
+				dct['tzinfo'] = obj.tzinfo.zone
+			else:
+				dct['tzinfo'] = obj.tzinfo.tzname(None)
 	elif isinstance(obj, date):
 		dct = hashodict([('__date__', None), ('year', obj.year), ('month', obj.month), ('day', obj.day)])
 	elif isinstance(obj, time):
 		dct = hashodict([('__time__', None), ('hour', obj.hour), ('minute', obj.minute),
 			('second', obj.second), ('microsecond', obj.microsecond)])
 		if obj.tzinfo:
-			dct['tzinfo'] = obj.tzinfo.tzname(None)
+			if hasattr(obj.tzinfo, 'zone'):
+				dct['tzinfo'] = obj.tzinfo.zone
+			else:
+				dct['tzinfo'] = obj.tzinfo.tzname(None)
 	elif isinstance(obj, timedelta):
 		if primitives:
 			return obj.total_seconds()

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -6,7 +6,7 @@ This tests timezone-aware date/time objects, which need pytz. Naive date/times s
 work with just Python code functionality, and are tested in `nonp`.
 """
 
-from datetime import datetime, date, time, timedelta
+from datetime import datetime, date, time, timedelta, timezone
 from json_tricks import dumps, loads
 from json_tricks.utils import is_py3
 import pytz
@@ -14,11 +14,13 @@ import pytz
 
 DTOBJ = [
 	datetime(year=1988, month=3, day=15, hour=8, minute=3, second=59, microsecond=7),
+	datetime.now(timezone.utc),
 	pytz.UTC.localize(datetime(year=1988, month=3, day=15, minute=3, second=59, microsecond=7)),
 	pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, microsecond=7)),
 	date(year=1988, month=3, day=15),
 	time(hour=8, minute=3, second=59, microsecond=123),
 	time(hour=8, second=59, microsecond=123, tzinfo=pytz.timezone('Europe/Amsterdam')),
+	time(hour=8, second=59, microsecond=123, tzinfo=timezone.utc),
 	timedelta(days=2, seconds=3599),
 	timedelta(days=0, seconds=-42, microseconds=123),
 	[{'obj': [pytz.timezone('Europe/Amsterdam').localize(datetime(year=1988, month=3, day=15, microsecond=7))]}],


### PR DESCRIPTION
```python
In [1]: from datetime import datetime, time, timezone

In [2]: import json_tricks

In [3]: dutc = datetime.now(timezone.utc)

In [4]: tutc = time(hour=1, tzinfo=timezone.utc)

In [5]: json_tricks.dumps(dutc)

Out [5]: Error

In [6]: json_tricks.dumps(tutc)

Out [6]: Error
```

Noticed this recently. I know you have #93 and im happy to rebase after.
