### PR TITLE
Add range object serialization

### DIFF
--- a/json_tricks/decoders.py
+++ b/json_tricks/decoders.py
@@ -159,6 +159,12 @@ def slice_hook(dct):
 		return dct
 	return slice(dct['start'], dct['stop'], dct['step'])
 
+def range_hook(dct):
+	if not isinstance(dct, dict):
+		return dct
+	if not '__range__' in dct:
+		return dct
+	return range(dct['start'], dct['stop'], dct['step'])
 
 class EnumInstanceHook(ClassInstanceHookBase):
 	"""

--- a/json_tricks/encoders.py
+++ b/json_tricks/encoders.py
@@ -298,6 +298,20 @@ def slice_encode(obj, primitives=False):
 			('step', obj.step),
 		))
 
+def range_encode(obj, primitives=False):
+	if not isinstance(obj, range):
+		return obj
+
+	if primitives:
+		return [obj.start, obj.stop, obj.step]
+	else:
+		return hashodict((
+			('__range__', True),
+			('start', obj.start),
+			('stop', obj.stop),
+			('step', obj.step),
+		))
+
 class ClassInstanceEncoder(JSONEncoder):
 	"""
 	See `class_instance_encoder`.

--- a/json_tricks/nonp.py
+++ b/json_tricks/nonp.py
@@ -10,13 +10,13 @@ from .comment import strip_comments  # keep 'unused' imports
 from .encoders import TricksEncoder, json_date_time_encode, \
 	class_instance_encode, json_complex_encode, json_set_encode, numeric_types_encode, numpy_encode, \
 	nonumpy_encode, nopandas_encode, pandas_encode, noenum_instance_encode, \
-	enum_instance_encode, pathlib_encode, bytes_encode, slice_encode  # keep 'unused' imports
+	enum_instance_encode, pathlib_encode, bytes_encode, slice_encode, range_encode  # keep 'unused' imports
 from .decoders import TricksPairHook, \
 	json_date_time_hook, ClassInstanceHook, \
 	json_complex_hook, json_set_hook, numeric_types_hook, json_numpy_obj_hook, \
 	json_nonumpy_obj_hook, \
 	nopandas_hook, pandas_hook, EnumInstanceHook, \
-	noenum_hook, pathlib_hook, nopathlib_hook, json_bytes_hook, slice_hook  # keep 'unused' imports
+	noenum_hook, pathlib_hook, nopathlib_hook, json_bytes_hook, slice_hook, range_hook  # keep 'unused' imports
 
 
 ENCODING = 'UTF-8'
@@ -33,6 +33,7 @@ DEFAULT_ENCODERS = [
     class_instance_encode,
     bytes_encode,
     slice_encode,
+    range_encode,
 ]
 
 DEFAULT_HOOKS = [
@@ -43,6 +44,7 @@ DEFAULT_HOOKS = [
     _cih_instance,
     json_bytes_hook,
     slice_hook,
+    range_hook,
 ]
 
 

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+from json_tricks import dumps, loads
+
+def test_range():
+    original_range = range(0, 10, 2)
+    json_range = dumps(original_range)
+    loaded_range = loads(json_range)
+    assert original_range == loaded_range
+
+def test_range_no_step():
+    original_range = range(0, 5)
+    json_range = dumps(original_range)
+    loaded_range = loads(json_range)
+    assert original_range == loaded_range


### PR DESCRIPTION
I ran into a case where this would be useful in one of my projects.

The signature is extremely similar to the `slice` objects signature so its has a very similar encoder and decoder. 

I could refactor this and merge the 2 if that would be preferred. 

Thanks!